### PR TITLE
Add 2.9.3 and handle bad stim gracefully

### DIFF
--- a/load_heka_python/load_heka.py
+++ b/load_heka_python/load_heka.py
@@ -21,7 +21,7 @@ def _import_trees(header):
     elif header["oVersion"] in ["v2x90.2, 22-Nov-2016"]:
         from .trees import Trees_v9 as Trees
 
-    elif header["oVersion"] in ["v2x90.5, 09-Apr-2019", "1.2.0 [Build 1469]", "v2x91, 23-Feb-2021"]:
+    elif header["oVersion"] in ["v2x90.3, 19-Mar-2018", "v2x90.5, 09-Apr-2019", "1.2.0 [Build 1469]", "v2x91, 23-Feb-2021"]:
         from .trees import Trees_v1000 as Trees
     else:
         raise Exception("Version not current supported, please contact support@easyelectrophysiology.com")

--- a/load_heka_python/readers/stim_reader.py
+++ b/load_heka_python/readers/stim_reader.py
@@ -25,7 +25,8 @@ def get_stimulus_for_series(pul, pgf, group_idx, series_idx):
 
     data = create_stimulus_waveform_from_segments(segments, info, num_sweeps_in_recorded_data)
 
-    check_data(data, pul_sweep, num_sweeps_in_recorded_data)
+    if not check_data(data, pul_sweep, num_sweeps_in_recorded_data):
+        return False
 
     info["data"] = data
     return info
@@ -76,7 +77,11 @@ def check_header(dac):
 
 def check_data(data, sweep, num_sweeps_in_recorded_data):
     rec_num_samples = sweep["ch"][0]["hd"]["TrDataPoints"]
-    assert rec_num_samples == data.shape[1], "reconstructed stimulis size is not the same as corresponding pulse tree record"
+    if rec_num_samples != data.shape[1]:
+        warnings.warn("Reconstructed stimulis size is not the same as corresponding pulse tree record."
+                      "Stimulus will be disregarded.")
+        return False
+
     assert num_sweeps_in_recorded_data == data.shape[0], "reconstructed stimulus size cannot be made equal to recorded number of sweeps"
 
 def read_segments_into_classes(dac, info):

--- a/load_heka_python/readers/stim_reader.py
+++ b/load_heka_python/readers/stim_reader.py
@@ -84,6 +84,8 @@ def check_data(data, sweep, num_sweeps_in_recorded_data):
 
     assert num_sweeps_in_recorded_data == data.shape[0], "reconstructed stimulus size cannot be made equal to recorded number of sweeps"
 
+    return True
+
 def read_segments_into_classes(dac, info):
     """
     Ignore unstored (i.e. unused) segments

--- a/test/ee_run_tests.py
+++ b/test/ee_run_tests.py
@@ -82,6 +82,21 @@ def test_f10_v2x91(base_path):
     group_num_series_num_to_test = [["1", "1"], ["1", "3"], ["1", "5"], ["1", "9"]]
     test_heka_reader(base_path, version, group_num_series_num_to_test, assert_mode=ASSERT_MODE)
 
+def test_f11_v2x90_3(base_path):
+    """
+    This is an annoying file that is offset by 0.05 s in the software (x_start = 0.05) but
+    cannot export it in such a way that it is relative to the sweep but maintains
+    the 0.05 s offset - the software is correcting it somewhere but not making the
+    option to turn off correction available (at least that I could find.
+    Nonetheless Vm is loading well so keep here as a successful test.
+
+    There is also a problem with the stimulus, which is all zeros in the
+    file but was loading with array dimension longer than the time of the recording
+    in load_heka, so is loaded as False.
+    """
+    version = "f11_v2x90.3"
+    group_num_series_num_to_test = [["1", "1"], ["1", "2"], ["1", "4"], ["1", "11"], ["1", "12"]]
+    test_heka_reader(base_path, version, group_num_series_num_to_test, assert_mode=False, include_stim_protocol=False)
 
 test_f1_v2x90_2(TEST_PATH)
 test_f2_v2x90_2(TEST_PATH)
@@ -93,3 +108,4 @@ f7_1_2_0_build_1469(TEST_PATH)
 test_f8_v2x65(TEST_PATH)
 test_f9_v2x65(TEST_PATH)
 test_f10_v2x91(TEST_PATH)
+test_f11_v2x90_3(TEST_PATH)

--- a/test/test_load_heka.py
+++ b/test/test_load_heka.py
@@ -5,17 +5,17 @@ from os.path import join
 
 def test_heka_reader(base_path, version, group_series_to_test, dp_thr=1e-6, info_type="mean_dp_match", assert_mode=False, include_stim_protocol=True):
     """
-    Test the data read my LoadHeka matches the the data when loading into Patchmaster. Data must be exported from Patchmaster
+    Test the data read my LoadHeka matches the data when loading into Patchmaster. Data must be exported from Patchmaster
     using 'Export Sweep' as ascii for comparison with LoadHeka. See the main README.md (section 5) on details
-    on the file organisation and Export sweep options expceted by this function.
+    on the file organisation and Export sweep options expected by this function.
 
     Note that all tests are conducted with units scaled to pA, mV, s.
 
     This test function is a little unusual as by default it does not assert to an exact match between the data and Patchmaster.
     For reasons that are not currently clear (have emailed HEKA) the Im and Vm data does not match the exported HEKA sweep
-    perfectly, but usually to around ~5 d.p. This varies a little between series. While this percision is sufficient, it would
+    perfectly, but usually to around ~5 d.p. This varies a little between series. While this precision is sufficient, it would
     be nice if they matched perfectly, and we could test with assert to 7 d.p. (similar to time and stimulus protocol, which are
-    not effected by this issue). Because of this, optiosn to print the average decimal place match, or the % of samples
+    not effected by this issue). Because of this, options to print the average decimal place match, or the % of samples
     that match to dp_thr decimal places is provided.
 
     base_path - path to the test directory (see README.md)
@@ -35,7 +35,7 @@ def test_heka_reader(base_path, version, group_series_to_test, dp_thr=1e-6, info
                 "assert_dp_match" - raise exception if any sample does not match Patchmaster to dp_thr decimal places or more
 
     assert_mode - Tests are usually printed so the results for all series are run. However, if assert_mode is True, an exception will be
-                  raised if data and Patchmaster do not matched to pre-set cutoff values (see TestSeries().handle_assert() for details.
+                  raised if data and Patchmaster do not match to pre-set cutoff values (see TestSeries().handle_assert() for details.
     """
     print("Testing " + version + "----------------------------------------------------------------------------------------------------------------\n")
 
@@ -79,7 +79,7 @@ def test_heka_reader(base_path, version, group_series_to_test, dp_thr=1e-6, info
 class TestSeries:
     def __init__(self, raw_heka, load_heka, group_num, series_num, dp_thr, im_or_vm, info_type, assert_mode, supress_time, supress_stim):
         """
-        Class to test the Data (Im or Vm), reconstructued stimulus and time against exported Patchmaster data. Data is converted to pA
+        Class to test the Data (Im or Vm), reconstructed stimulus and time against exported Patchmaster data. Data is converted to pA
         and mV. For a reason that is not clear, the output of the Im and Vm data does not match HEKA perfectly, but to around 5 decimal
         places on average. This precision is sufficient but we have emailed HEKA to check if any additional settings are causing
         this slight difference. See test_heka_reader() for details.

--- a/test/test_load_heka.py
+++ b/test/test_load_heka.py
@@ -1,6 +1,6 @@
 import warnings
 import numpy as np
-from load_heka.load_heka import LoadHeka
+from load_heka_python.load_heka import LoadHeka
 from os.path import join
 
 def test_heka_reader(base_path, version, group_series_to_test, dp_thr=1e-6, info_type="mean_dp_match", assert_mode=False, include_stim_protocol=True):


### PR DESCRIPTION
- add v2x90.3 and tests
- handle more gracefully the instance where stimulus size is not the same as data. This is quite unexpected, for this file
the stimulus was all zero anyway, but the error occured. Now just disregard the stimulus and throw a warning, rather than stop execution.
- some minor typos.