### PR TITLE
Add additional metadata to 'get_series_data', some metadata renames and minor bug fixes.

### DIFF
--- a/load_heka_python/load_heka.py
+++ b/load_heka_python/load_heka.py
@@ -39,7 +39,7 @@ def _import_trees(header):
     ]:
         from .trees import Trees_v1000 as Trees
     else:
-        raise Exception("Version not current supported, please contact support@easyelectrophysiology.com")
+        raise BaseException("Version not current supported, please contact support@easyelectrophysiology.com")
 
     return Trees
 
@@ -94,7 +94,7 @@ class LoadHeka:
         header = self._unpack_header(BundleHeader())
 
         if not header["oIsLittleEndian"]:
-            raise Exception("Big endian on the header not tested ")
+            raise BaseException("Big endian on the header not tested ")
             self.fh.seek(0)
             header = self._unpack_header(BundleHeader(), ">")
 
@@ -373,7 +373,7 @@ class LoadHeka:
             endian = "<"
         elif magic == b"Tree":
             endian = ">"
-            raise Exception("Big endian not tested yet")
+            raise BaseException("Big endian not tested yet")
 
         levels = struct.unpack(endian + "i", self.fh.read(4))[0]
         sizes = struct.unpack(endian + "i" * levels, self.fh.read(4 * levels))

--- a/load_heka_python/readers/data_reader.py
+++ b/load_heka_python/readers/data_reader.py
@@ -75,14 +75,14 @@ def get_dataformat(idx):
         return "h", 2, np.int16, "int16"
 
     elif idx == 1:
-        raise Exception("int32 datatype not tested ")
+        raise BaseException("int32 datatype not tested ")
         return "i", 4, np.int32, "int32"
 
     elif idx == 2:
         return "f", 4, np.float32, "float32"
 
     elif idx == 3:
-        raise Exception("double datatype not tested")
+        raise BaseException("double datatype not tested")
         return "d", 8, np.float64, "float64"
 
 
@@ -143,7 +143,7 @@ def get_series_channels(pul, group_idx, series_idx):
     for chan_idx in range(num_channels):
         for key in param_dict.keys():
             if not len(np.unique(channels[chan_idx][key])) == 1:
-                raise Exception(
+                raise BaseException(
                     "channel parameters are not the same across series for '{0}' series {1}".format(key, series_idx)
                 )
 

--- a/load_heka_python/run_test_load_heka.py
+++ b/load_heka_python/run_test_load_heka.py
@@ -24,7 +24,7 @@ def test_file(test_path, dp_thr=1e-6, info_type="max_dp_match", assert_mode=Fals
     filenames = list(map(basename, ascii_files))
 
     if len(ascii_files) == 0:
-        raise Exception("no files found in " + base_path)
+        raise BaseException("no files found in " + base_path)
 
     group_series_to_test = [[filename.split("group-")[1][0], filename.split("series-")[1][0]] for filename in filenames]
 

--- a/load_heka_python/test/runners.py
+++ b/load_heka_python/test/runners.py
@@ -46,14 +46,7 @@ def heka_reader_tester(
 
         raw_heka = read_heka_test_ascii(join(base_path, version, filename), has_leak)
 
-        # calculate number of channels (if channel not included in ascii it will
-        # be all Nan.
-        num_channels = np.sum(
-            [not np.all(np.isnan(np.hstack(raw_heka["Im"]))), not np.all(np.isnan(np.hstack(raw_heka["Vm"])))],
-            dtype=np.int64,
-        )
-        if "leak" in raw_heka.keys():
-            num_channels += 1
+        num_channels = num_channels_from_raw_heka(raw_heka)
 
         supress_time = supress_stim = False
         for channel_idx in range(num_channels):
@@ -89,6 +82,21 @@ def heka_reader_tester(
                 supress_time = True
 
         print("\n")
+
+
+def num_channels_from_raw_heka(raw_heka):
+    """
+    Calculate number of channels (if channel not
+    included in ascii it will be all Nan.
+    """
+    num_channels = np.sum(
+        [not np.all(np.isnan(np.hstack(raw_heka["Im"]))), not np.all(np.isnan(np.hstack(raw_heka["Vm"])))],
+        dtype=np.int64,
+    )
+    if "leak" in raw_heka.keys():
+        num_channels += 1
+
+    return num_channels
 
 
 class SeriesTest:


### PR DESCRIPTION
This PR adds additional metadata to the output of the `get_series_data` function. `ts` metadata is also renamed to `sampling_step`. Finally, a minor bugfix to the edge case when the Vm channel is in mV even though the data is in volts. 