### PR TITLE
Expose zero offset and additional stimulus reconstruction arguments (+ version release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ This will ensure the file is closed automatically once the block has finished.
 
 The `heka_file` object initially contains only header information. With calls
 to `get_series_data()` data will be filled internally on the object, as well
-as being returned from the function. Later calls to `get_series_data()`
-will overwrite previous data internally within the object.
+as being returned from the function. Under the good, calls to `get_series_data()`
+will overwrite previous data internally within the object with the currently
+selected settings. It is recommended to always use `get_series_data` to
+retrieve data.
 
 #### File Structure
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # Heka Loader for Python
 
-1) Introduction and Acknowledgements
-2) Usage Instructions
-3) Lazy Loading
-4) Supported File Versions and Recording Settings
-5) Testing your files
-
-## 1) Introduction and Acknowledgements
+## Introduction and Acknowledgements
 
 This module will load HEKA files created by PatchMaster software into Python. Note this module
 is still in the testing phase, please see section 4 and 5 for details.
@@ -18,11 +12,6 @@ Inspiration has also been taken from Christian Keine / Sammy Katta's [MATLAB HEK
 We would also like to acknowledge [Stimfits HEKA module](https://github.com/neurodroid/stimfit) and [SigTools module](https://pubmed.ncbi.nlm.nih.gov/19056423/)
 on which the above examples were based, and HEKA for their detailed documentation on the filetype, available the network drive: server.hekahome.de
 
-## 2) Usage Instructions
-
-By default, the HEKA loader will load the entire file (i.e. header information + data) into memory.
-The argument only_load_header=True can be used for lazy loading (i.e. only loading the header into memory,
-before specifying which series data to load, see section 3).
 
 ### Getting Started
 
@@ -36,7 +25,7 @@ from load_heka_python.load_heka import LoadHeka
 
 full_path_to_file = r"C:\path\to\a\file.dat"
 
-heka_file = LoadHeka(full_path_to_file)
+heka_file = LoadHeka(full_path_to_file)  # only loads header information
 series_data = heka_file.get_series_data(group_idx=0, series_idx=0, channel_idx=0)
 heka_file.close()
 ```
@@ -50,6 +39,11 @@ with LoadHeka(full_path_to_file) as heka_file:
 	series_data = heka_file.get_series_data(group_idx=0, series_idx=0, channel_idx=0)
 ```
 This will ensure the file is closed automatically once the block has finished.
+
+The `heka_file` object initially contains only header information. With calls
+to `get_series_data()` data will be filled internally on the object, as well
+as being returned from the function. Later calls to `get_series_data()`
+will overwrite previous data internally within the object.
 
 #### File Structure
 
@@ -95,7 +89,15 @@ Public Functions:
 ```
 heka_file.print_group_names()
 heka_file.print_series_names(group_idx)
-heka_file.get_series_data(group_idx=group_idx, series_idx=0, channel_idx=0, include_stim_protocol=bool)
+
+heka_file.get_series_data(
+    group_idx=group_idx,
+    series_idx=0,
+    channel_idx=0,
+    include_stim_protocol=True
+    add_zero_offset=True,
+    stim_channel_idx=None,
+)
 ```
 First, to get the indexes of the group and series you want to load, you can use:
 ```
@@ -126,24 +128,12 @@ This will return the dictionary data with series:
 
 as well as number of fields `("labels", "ts", "data_kinds", "num_samples", "t_starts", "t_stops")` containing information for each sweep.
 
-
 In theory, these are the only methods you will need to use, however the class has many private methods that might be useful (see source code).
 
-
-## 3) Lazy Loading
-
-By default, the entire file is loaded into memory (i.e. the `["data"]` field of the pulse records
-are all filled).
-
-However, as HEKA files can be very large (e.g. ~200 MB) options are provided
-for 'lazy' loading. This will only load the header information and no data. To load the data, the function `get_series_data()` is used.
-
-If the series is loaded with `get_series_data()`, then this selected series only
-will be loaded into memory (i.e. the `["data"]` fields on the pulse tree, on the selected records only, will be filled)
-before the data is returned.
+See the function docstring full details on the function arguments.
 
 
-## 4) Supported File Versions and Recording Settings
+## Supported File Versions and Recording Settings
 
 HEKA has been in business for over 40 years and as such has many file versions. Furthermore,
 it is a highly flexible filetype with many many options and parameter combinations.
@@ -154,14 +144,16 @@ button and comparing the output of LoadHeka to this (see test_load_heka). As mor
 these will be added to the test suite and supported.
 
 When using this module for the first time, please check that your data appears as it does in the PatchMaster file.
-Also, please send your files to support@easyelectrophysiology.com so they can be added to our test suite. Please open an Issue in case of any problems.
+Also, please send your files to support@easyelectrophysiology.com so they can be added to our test suite.
+Please open an Issue in case of any problems.
 
 Known settings currently not tested / supported:
 - big endian encoding
 - data stored as int32 and float64
 - virtual data
 - units not in s, A, V
-- currently only Constant (positive), Ramp (positive) and Continuous stimulus protocol reconstruction is supported
+- currently only Constant (positive), Ramp (positive) and Continuous stimulus protocol reconstruction is supported.
+  Other modes may be exposed in the `include_stim_protocol="experimental"` mode.
 
 However, there may be other setting combinations that have not been anticipated. So far, all tested files match the HEKA
 data output well (see `./test/test_load_heka.py` for details). Again, please send your files to support@easyelectrophysiology.com so they can be added
@@ -186,7 +178,7 @@ v1000
         v2x92
 	v1.2
 ```
-## 5) Testing Your Files
+## Testing Your Files
 
 Options are provided to test the data read by LoadHeka against the data as displayed in Patchmaster. This is recommended during the ongoing testing phase.
 

--- a/load_heka_python/load_heka.py
+++ b/load_heka_python/load_heka.py
@@ -433,6 +433,8 @@ class LoadHeka:
             fill_with_mean - by default, if sweep data is smaller than others in the series, it will be padded with NaN. This option
                              will override this and set as the mean of the trace.
 
+            add_zero_offset - if `True`, offset is added to scale the resting potential to zero.
+
             stim_channel_index - if `None`, the first stimulus channel with a non-zero seVoltage field will be used. Otherwise,
                                  this can be manually specified with an integer index.
 

--- a/load_heka_python/load_heka.py
+++ b/load_heka_python/load_heka.py
@@ -464,6 +464,7 @@ class LoadHeka:
             "units": [],
             "stim": None,
             "sampling_step": [],
+            "zero_offsets": [],
             "dtype": "float64",  # note this is after processing (not the original stored data)
         }
 
@@ -512,6 +513,8 @@ class LoadHeka:
             t_stop = t_start + (num_samples * ts)
             out["t_stops"].append(t_stop)
 
+            out["zero_offsets"].append(sweep["ch"][channel_idx]["hd"]["TrZeroData"])
+
             out["time"][sweep_idx, :] = np.arange(max_num_samples) * ts + t_start
 
             out["data"][sweep_idx, 0:num_samples] = sweep["ch"][channel_idx]["data"]
@@ -521,7 +524,13 @@ class LoadHeka:
                 out["data"][sweep_idx, num_samples:] = fill
 
         for key in out.keys():
-            if isinstance(out[key], list) and key not in ["t_starts", "t_stops", "num_samples", "data_kinds"]:
+            if isinstance(out[key], list) and key not in [
+                "t_starts",
+                "t_stops",
+                "num_samples",
+                "data_kinds",
+                "zero_offsets",
+            ]:
                 assert self.all_equal(out[key]), (
                     "Key parameters that differ " "across sweeps are not currently supported."
                 )

--- a/load_heka_python/load_heka.py
+++ b/load_heka_python/load_heka.py
@@ -374,14 +374,14 @@ class LoadHeka:
 
         return endian, levels, sizes
 
-    def get_stimulus_for_series(self, group_idx, series_idx, stim_channel_idx, experimental_mode):
+    def get_stimulus_for_series(self, group_idx, series_idx, experimental_mode, stim_channel_idx):
 
         if self.version in OLD_VERSIONS:
             warnings.warn("Stimulus reconstruction for versions before 2x90 is not supported")
             return False
 
         series_stim = stim_reader.get_stimulus_for_series(
-            self.pul, self.pgf, group_idx, series_idx, stim_channel_idx, experimental_mode
+            self.pul, self.pgf, group_idx, series_idx, experimental_mode, stim_channel_idx
         )
         return series_stim
 
@@ -468,14 +468,14 @@ class LoadHeka:
         num_rows = len(series["ch"])
         max_num_samples = self._get_max_num_samples_from_sweeps_in_series(series["ch"])
 
-        if np.any(series["ch"][0]["ch"][0]["data"]):
-            warnings.warn("Data already exists for the group, series index. Overwriting...")
-
         data_reader.fill_pul_with_data(self.pul, self.fh, group_idx, series_idx, add_zero_offset)
 
         if include_stim_protocol:
             out["stim"] = self.get_stimulus_for_series(
-                group_idx, series_idx, stim_channel_idx, experimental_mode=include_stim_protocol == "experimental"
+                group_idx,
+                series_idx,
+                experimental_mode=include_stim_protocol == "experimental",
+                stim_channel_idx=stim_channel_idx,
             )
 
         for key in ["data", "time"]:

--- a/load_heka_python/load_heka.py
+++ b/load_heka_python/load_heka.py
@@ -36,6 +36,7 @@ def _import_trees(header):
         "v2x91, 23-Feb-2021",
         "v2x91, 06-Jul-2020",
         "v2x92, 23-February-2023",
+        "v2x92, 1-June-2023",
     ]:
         from .trees import Trees_v1000 as Trees
     else:

--- a/load_heka_python/readers/data_reader.py
+++ b/load_heka_python/readers/data_reader.py
@@ -3,7 +3,7 @@ import numpy as np
 import struct
 
 
-def fill_pul_with_data(pul, fh, group_idx, series_idx):
+def fill_pul_with_data(pul, fh, group_idx, series_idx, add_zero_offset):
     """
     Fill the ["data"] field of all pulse tree records for the specified group and series with raw data from file.
 
@@ -46,10 +46,26 @@ def fill_pul_with_data(pul, fh, group_idx, series_idx):
             # Scale and recast to float64
             if np_dtype in [np.int16, np.int32]:
                 scaling_factor = np.array(rec["hd"]["TrDataScaler"], dtype=np.float64)
-                data = (data * scaling_factor) - rec["hd"]["TrZeroData"]
+
+                data = data * scaling_factor
+
+                if add_zero_offset:
+                    data -= rec["hd"]["TrZeroData"]
 
             elif np_dtype == np.float32:
+                raise NotImplemented(
+                    "The zero scaling on float32 data must be checked. Please contact "
+                    "Easy Electrophysiology. To revert to previous behaviour, downgrade "
+                    "to v1.0.0"
+                )
                 data = data.astype(np.float64)
+
+            elif np_dtype == np.float64:
+                raise NotImplemented(
+                    "The zero scaling on float64 data must be checked. Please contact "
+                    "Easy Electrophysiology. To revert to previous behaviour, downgrade "
+                    "to v1.0.0"
+                )
 
             rec["data"] = data
 
@@ -91,7 +107,7 @@ def get_dataformat(idx):
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
 
 
-def get_channel_parameters_across_all_series(pul, group_idx):  # DOC THIS
+def get_channel_parameters_across_all_series(pul, group_idx):
 
     num_series = len(pul["ch"][group_idx]["ch"])
 

--- a/load_heka_python/readers/data_reader.py
+++ b/load_heka_python/readers/data_reader.py
@@ -57,23 +57,11 @@ def fill_pul_with_data(pul, fh, group_idx, series_idx, add_zero_offset):
 
                 data = data * scaling_factor
 
-                if add_zero_offset:
-                    data -= rec["hd"]["TrZeroData"]
-
             elif np_dtype == np.float32:
-                raise NotImplementedError(
-                    "The zero scaling on float32 data must be checked. Please contact "
-                    "Easy Electrophysiology. To revert to previous behaviour, downgrade "
-                    "to v1.0.0"
-                )
                 data = data.astype(np.float64)
 
-            elif np_dtype == np.float64:
-                raise NotImplementedError(
-                    "The zero scaling on float64 data must be checked. Please contact "
-                    "Easy Electrophysiology. To revert to previous behaviour, downgrade "
-                    "to v1.0.0"
-                )
+            if add_zero_offset:
+                data -= rec["hd"]["TrZeroData"]
 
             rec["data"] = data
 

--- a/load_heka_python/readers/data_reader.py
+++ b/load_heka_python/readers/data_reader.py
@@ -1,6 +1,7 @@
 import copy
 import numpy as np
 import struct
+import warnings
 
 
 def fill_pul_with_data(pul, fh, group_idx, series_idx, add_zero_offset):
@@ -11,8 +12,15 @@ def fill_pul_with_data(pul, fh, group_idx, series_idx, add_zero_offset):
     """
     series = pul["ch"][group_idx]["ch"][series_idx]
 
+    if np.any(series["ch"][0]["ch"][0]["data"]):
+        warnings.warn("Data already exists for the passed group, series index. Overwriting...")
+
     for sweep in series["ch"]:
         for rec in sweep["ch"]:
+
+            # Just make sure whatever happens, any existing
+            # data is cleared to avoid confusion.
+            rec["data"] = None
 
             start = rec["hd"]["TrData"]
             length = rec["hd"]["TrDataPoints"]
@@ -53,7 +61,7 @@ def fill_pul_with_data(pul, fh, group_idx, series_idx, add_zero_offset):
                     data -= rec["hd"]["TrZeroData"]
 
             elif np_dtype == np.float32:
-                raise NotImplemented(
+                raise NotImplementedError(
                     "The zero scaling on float32 data must be checked. Please contact "
                     "Easy Electrophysiology. To revert to previous behaviour, downgrade "
                     "to v1.0.0"
@@ -61,7 +69,7 @@ def fill_pul_with_data(pul, fh, group_idx, series_idx, add_zero_offset):
                 data = data.astype(np.float64)
 
             elif np_dtype == np.float64:
-                raise NotImplemented(
+                raise NotImplementedError(
                     "The zero scaling on float64 data must be checked. Please contact "
                     "Easy Electrophysiology. To revert to previous behaviour, downgrade "
                     "to v1.0.0"

--- a/load_heka_python/readers/stim_reader.py
+++ b/load_heka_python/readers/stim_reader.py
@@ -9,7 +9,7 @@ warnings.simplefilter("always", UserWarning)
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
 
 
-def get_stimulus_for_series(pul, pgf, group_idx, series_idx, stim_channel_idx, experimental_mode):
+def get_stimulus_for_series(pul, pgf, group_idx, series_idx, experimental_mode, stim_channel_idx):
     """
     Reconstruct the stimulus from the stimulus protocol stored in StimTree.
 
@@ -57,6 +57,11 @@ def get_dac_and_important_params(stim_sweep, stim_channel_idx):
 
     stim_sweep : "hd" and "ch" for stimulus protocols
 
+    stim_channel_idx : If `None`, search through the stimulus channels
+        for the first entry with a nonzero seVoltage. If all have seVoltage of zero,
+        the first channel is arbitrarily chosen. Otherwise, an integer index
+        specifying the channel to reconstruct the signal from.
+
     For each channel, we have chan["hd"] or chan["ch"] containing
     information on each 'segment' of the stimulus. The stimulus division
     into segments splits the stimulus by pulse information. So, if we have for
@@ -88,11 +93,11 @@ def get_dac_and_important_params(stim_sweep, stim_channel_idx):
     }
 
     if info["units"] == "mV":
-        # weird heka feature where stim is as mV but stored in A, I think mV might just be how it is displayed in patchmaster
+        # weird HEKA feature where stim is as mV but stored in A,
+        # I think mV might just be how it is displayed in Patchmaster.
         warnings.warn(
-            "Stimulus units are specified {0} but (almost certainly) stored as V). Please check. Updating to V.".format(
-                info["units"]
-            )
+            "Stimulus units are specified {0} but (almost certainly) stored as V). "
+            "Please check. Updating to V.".format(info["units"])
         )  # e.g. 1 instance of units mV but the data was still stored as V...
         info["units"] = "V"
 

--- a/load_heka_python/readers/stim_reader.py
+++ b/load_heka_python/readers/stim_reader.py
@@ -9,7 +9,7 @@ warnings.simplefilter("always", UserWarning)
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
 
 
-def get_stimulus_for_series(pul, pgf, group_idx, series_idx, stim_chanel_idx, experimental_mode):
+def get_stimulus_for_series(pul, pgf, group_idx, series_idx, stim_channel_idx, experimental_mode):
     """
     Reconstruct the stimulus from the stimulus protocol stored in StimTree.
 
@@ -18,7 +18,7 @@ def get_stimulus_for_series(pul, pgf, group_idx, series_idx, stim_chanel_idx, ex
     """
     stim_sweep, pul_sweep, num_sweeps_in_recorded_data = get_sweep_info(pul, pgf, group_idx, series_idx)
 
-    dac, info = get_dac_and_important_params(stim_sweep, stim_chanel_idx)
+    dac, info = get_dac_and_important_params(stim_sweep, stim_channel_idx)
 
     if not check_header(dac, experimental_mode):
         return False
@@ -50,7 +50,7 @@ def get_sweep_info(pul, pgf, group_idx, series_idx):
     return stim_sweep, pul_sweep, num_sweeps_in_recorded_data
 
 
-def get_dac_and_important_params(stim_sweep, stim_chanel_idx):
+def get_dac_and_important_params(stim_sweep, stim_channel_idx):
     """
     Guessing from the (as far as known, undocumented) stimulus structure
     organisation, we have:
@@ -65,14 +65,17 @@ def get_dac_and_important_params(stim_sweep, stim_chanel_idx):
     on the signal and period length for each segment. The "hd" holds the
     stimulus metadata.
     """
-    if stim_chanel_idx is None:
+    if stim_channel_idx is None:
         for idx, chan in enumerate(stim_sweep["ch"]):
             for inner_chan in chan["ch"]:
                 if inner_chan["hd"]["seVoltage"] != 0:
-                    stim_chanel_idx = idx
+                    stim_channel_idx = idx
                     break
 
-    dac = stim_sweep["ch"][stim_chanel_idx]
+    if stim_channel_idx is None:
+        stim_channel_idx = 0
+
+    dac = stim_sweep["ch"][stim_channel_idx]
 
     info = {
         "name": "dac",

--- a/load_heka_python/test/runners.py
+++ b/load_heka_python/test/runners.py
@@ -5,7 +5,15 @@ from os.path import join
 
 
 def heka_reader_tester(
-    base_path, version, group_series_to_test, dp_thr=1e-6, assert_time=True, include_stim_protocol=True, has_leak=False
+    base_path,
+    version,
+    group_series_to_test,
+    dp_thr=1e-6,
+    assert_time=True,
+    include_stim_protocol=True,
+    has_leak=False,
+    add_zero_offset=True,
+    stim_channel_idx=0,
 ):
     """
     Test the data read my LoadHeka matches the data when loading into Patchmaster. Data must be exported from Patchmaster
@@ -38,7 +46,7 @@ def heka_reader_tester(
         + "----------------------------------------------------------------------------------------------------------------\n"
     )
 
-    heka_file = LoadHeka(join(base_path, version, version + ".dat"), only_load_header=True)
+    heka_file = LoadHeka(join(base_path, version, version + ".dat"))
 
     for group_num, series_num in group_series_to_test:
         print(f"group: {group_num} series: {series_num}")
@@ -57,6 +65,8 @@ def heka_reader_tester(
                 channel_idx,
                 include_stim_protocol=include_stim_protocol,
                 fill_with_mean=True,
+                add_zero_offset=add_zero_offset,
+                stim_channel_idx=stim_channel_idx,
             )
 
             if load_heka["data_kinds"][0]["IsLeak"]:


### PR DESCRIPTION
- Add 'experimental_mode' for stimulus reconstruction which attempts to construct some stimulus but not certain exactly how these are encoded in the HEKA metadata
- `add_zero_offset`  adds the offset stored in the HEKA metadata which scales the resting membrane potential to 0